### PR TITLE
populate periodic tasks after deployment

### DIFF
--- a/backend/core/management/commands/populate-periodic-tasks.py
+++ b/backend/core/management/commands/populate-periodic-tasks.py
@@ -1,0 +1,65 @@
+from django.core.management.base import BaseCommand
+from django_celery_beat.models import CrontabSchedule, PeriodicTask, IntervalSchedule
+
+
+class Command(BaseCommand):
+    help = "add default periodic tasks (3 audits per day | Fetch the available WPT configurations directly on installs | Update of available WPT configurations every night | Cleanup of old audit statuses every night)"
+
+    def handle(self, *args, **options):
+        schedule_1, _ = CrontabSchedule.objects.get_or_create(
+            minute="0", hour="1", day_of_week="*", day_of_month="*", month_of_year="*"
+        )
+        schedule_2, _ = CrontabSchedule.objects.get_or_create(
+            minute="0", hour="2", day_of_week="*", day_of_month="*", month_of_year="*"
+        )
+        schedule_7, _ = CrontabSchedule.objects.get_or_create(
+            minute="0", hour="7", day_of_week="*", day_of_month="*", month_of_year="*"
+        )
+        schedule_12, _ = CrontabSchedule.objects.get_or_create(
+            minute="0", hour="12", day_of_week="*", day_of_month="*", month_of_year="*"
+        )
+        schedule_16, _ = CrontabSchedule.objects.get_or_create(
+            minute="0", hour="16", day_of_week="*", day_of_month="*", month_of_year="*"
+        )
+
+        PeriodicTask.objects.create(
+            crontab=schedule_7,
+            name="Run all audits 1",
+            task="audits.tasks.request_all_audits",
+        )
+        PeriodicTask.objects.create(
+            crontab=schedule_12,
+            name="Run all audits 2",
+            task="audits.tasks.request_all_audits",
+        )
+        PeriodicTask.objects.create(
+            crontab=schedule_16,
+            name="Run all audits 3",
+            task="audits.tasks.request_all_audits",
+        )
+
+        PeriodicTask.objects.create(
+            crontab=schedule_1,
+            name="Get all wpt audit configurations",
+            task="audits.tasks.get_wpt_audit_configurations",
+        )
+
+        PeriodicTask.objects.create(
+            crontab=schedule_2,
+            name="clean old audits statuses",
+            task="audits.tasks.clean_old_audit_statuses",
+        )
+
+        schedule_seconds, _ = IntervalSchedule.objects.get_or_create(
+            every=1, period=IntervalSchedule.SECONDS
+        )
+        PeriodicTask.objects.create(
+            interval=schedule_seconds,
+            name="One shot update all configurations",
+            task="audits.tasks.get_wpt_audit_configurations",
+            one_off=True,
+        )
+
+        self.stdout.write(
+            self.style.SUCCESS("Successfully genereated default Crontabs")
+        )

--- a/backend/core/tests/management/commands/test_populateperiodictasks.py
+++ b/backend/core/tests/management/commands/test_populateperiodictasks.py
@@ -1,0 +1,12 @@
+from django_celery_beat.models import PeriodicTask
+from django.core.management import call_command
+from django.test import TestCase
+
+
+class ClosepollTest(TestCase):
+    def test_nb_of_periodicTasks_generated(self):
+        nb_before_command = len(PeriodicTask.objects.all())
+        call_command("populate-periodic-tasks")
+        nb_after_command = len(PeriodicTask.objects.all())
+
+        self.assertEqual(nb_after_command - nb_before_command, 6)

--- a/postdeploy.sh
+++ b/postdeploy.sh
@@ -1,5 +1,6 @@
 if [[ -z "${IS_REVIEW_APP}" ]]; then
     ./manage.py shell -c "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('admin', '$EMAIL_ADMIN', 'admin')"
+    ./manage.py populate-periodic-tasks
 else
     ./manage.py loaddata fixtures/fixtures.json
 fi


### PR DESCRIPTION
resolves #29 

to avoid long inline shell command, I propose to create a command

The result after running the command `python manage.py populate-periodic-tasks` in local :
![image](https://user-images.githubusercontent.com/45398769/67214016-52185280-f41f-11e9-8b4b-44bf286f9c9e.png)
