### PR TITLE
Add auto-generated swagger docs

### DIFF
--- a/backend/Pipfile
+++ b/backend/Pipfile
@@ -21,6 +21,7 @@ djoser = "==1.5.1"
 django-fernet-fields = "==0.5"
 whitenoise = "*"
 django-heroku = "*"
+drf-yasg = "*"
 
 [dev-packages]
 "flake8" = "==3.7.7"

--- a/backend/Pipfile.lock
+++ b/backend/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "753e57ed8e83246ec64c049f97c19d2cd0dacfa0f5512b1a170219e678b799e8"
+            "sha256": "5c492644fb1cea8bf36513248d68bb7f88f4a8dd68718bc9fa6cd35d3a12a8ee"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -89,40 +89,38 @@
         },
         "cffi": {
             "hashes": [
-                "sha256:08f99e8b38d5134d504aa7e486af8e4fde66a2f388bbecc270cdd1e00fa09ff8",
-                "sha256:1112d2fc92a867a6103bce6740a549e74b1d320cf28875609f6e93857eee4f2d",
-                "sha256:1b9ab50c74e075bd2ae489853c5f7f592160b379df53b7f72befcbe145475a36",
-                "sha256:24eff2997436b6156c2f30bed215c782b1d8fd8c6a704206053c79af95962e45",
-                "sha256:2eff642fbc9877a6449026ad66bf37c73bf4232505fb557168ba5c502f95999b",
-                "sha256:362e896cea1249ed5c2a81cf6477fabd9e1a5088aa7ea08358a4c6b0998294d2",
-                "sha256:40eddb3589f382cb950f2dcf1c39c9b8d7bd5af20665ce273815b0d24635008b",
-                "sha256:5ed40760976f6b8613d4a0db5e423673ca162d4ed6c9ed92d1f4e58a47ee01b5",
-                "sha256:632c6112c1e914c486f06cfe3f0cc507f44aa1e00ebf732cedb5719e6aa0466a",
-                "sha256:64d84f0145e181f4e6cc942088603c8db3ae23485c37eeda71cb3900b5e67cb4",
-                "sha256:6cb4edcf87d0e7f5bdc7e5c1a0756fbb37081b2181293c5fdf203347df1cd2a2",
-                "sha256:6f19c9df4785305669335b934c852133faed913c0faa63056248168966f7a7d5",
-                "sha256:719537b4c5cd5218f0f47826dd705fb7a21d83824920088c4214794457113f3f",
-                "sha256:7b0e337a70e58f1a36fb483fd63880c9e74f1db5c532b4082bceac83df1523fa",
-                "sha256:853376efeeb8a4ae49a737d5d30f5db8cdf01d9319695719c4af126488df5a6a",
-                "sha256:85bbf77ffd12985d76a69d2feb449e35ecdcb4fc54a5f087d2bd54158ae5bb0c",
-                "sha256:8978115c6f0b0ce5880bc21c967c65058be8a15f1b81aa5fdbdcbea0e03952d1",
-                "sha256:8f7eec920bc83692231d7306b3e311586c2e340db2dc734c43c37fbf9c981d24",
-                "sha256:8fe230f612c18af1df6f348d02d682fe2c28ca0a6c3856c99599cdacae7cf226",
-                "sha256:92068ebc494b5f9826b822cec6569f1f47b9a446a3fef477e1d11d7fac9ea895",
-                "sha256:b57e1c8bcdd7340e9c9d09613b5e7fdd0c600be142f04e2cc1cc8cb7c0b43529",
-                "sha256:ba956c9b44646bc1852db715b4a252e52a8f5a4009b57f1dac48ba3203a7bde1",
-                "sha256:ca42034c11eb447497ea0e7b855d87ccc2aebc1e253c22e7d276b8599c112a27",
-                "sha256:dc9b2003e9a62bbe0c84a04c61b0329e86fccd85134a78d7aca373bbbf788165",
-                "sha256:dd308802beb4b2961af8f037becbdf01a1e85009fdfc14088614c1b3c383fae5",
-                "sha256:e77cd105b19b8cd721d101687fcf665fd1553eb7b57556a1ef0d453b6fc42faa",
-                "sha256:f56dff1bd81022f1c980754ec721fb8da56192b026f17f0f99b965da5ab4fbd2",
-                "sha256:fa4cc13c03ea1d0d37ce8528e0ecc988d2365e8ac64d8d86cafab4038cb4ce89",
-                "sha256:fa8cf1cb974a9f5911d2a0303f6adc40625c05578d8e7ff5d313e1e27850bd59",
-                "sha256:fb003019f06d5fc0aa4738492ad8df1fa343b8a37cbcf634018ad78575d185df",
-                "sha256:fd409b7778167c3bcc836484a8f49c0e0b93d3e745d975749f83aa5d18a5822f",
-                "sha256:fe5d65a3ee38122003245a82303d11ac05ff36531a8f5ce4bc7d4bbc012797e1"
+                "sha256:00d890313797d9fe4420506613384b43099ad7d2b905c0752dbcc3a6f14d80fa",
+                "sha256:0cf9e550ac6c5e57b713437e2f4ac2d7fd0cd10336525a27224f5fc1ec2ee59a",
+                "sha256:0ea23c9c0cdd6778146a50d867d6405693ac3b80a68829966c98dd5e1bbae400",
+                "sha256:193697c2918ecdb3865acf6557cddf5076bb39f1f654975e087b67efdff83365",
+                "sha256:1ae14b542bf3b35e5229439c35653d2ef7d8316c1fffb980f9b7647e544baa98",
+                "sha256:1e389e069450609c6ffa37f21f40cce36f9be7643bbe5051ab1de99d5a779526",
+                "sha256:263242b6ace7f9cd4ea401428d2d45066b49a700852334fd55311bde36dcda14",
+                "sha256:33142ae9807665fa6511cfa9857132b2c3ee6ddffb012b3f0933fc11e1e830d5",
+                "sha256:364f8404034ae1b232335d8c7f7b57deac566f148f7222cef78cf8ae28ef764e",
+                "sha256:47368f69fe6529f8f49a5d146ddee713fc9057e31d61e8b6dc86a6a5e38cecc1",
+                "sha256:4895640844f17bec32943995dc8c96989226974dfeb9dd121cc45d36e0d0c434",
+                "sha256:558b3afef987cf4b17abd849e7bedf64ee12b28175d564d05b628a0f9355599b",
+                "sha256:5ba86e1d80d458b338bda676fd9f9d68cb4e7a03819632969cf6d46b01a26730",
+                "sha256:63424daa6955e6b4c70dc2755897f5be1d719eabe71b2625948b222775ed5c43",
+                "sha256:6381a7d8b1ebd0bc27c3bc85bc1bfadbb6e6f756b4d4db0aa1425c3719ba26b4",
+                "sha256:6381ab708158c4e1639da1f2a7679a9bbe3e5a776fc6d1fd808076f0e3145331",
+                "sha256:6fd58366747debfa5e6163ada468a90788411f10c92597d3b0a912d07e580c36",
+                "sha256:728ec653964655d65408949b07f9b2219df78badd601d6c49e28d604efe40599",
+                "sha256:7cfcfda59ef1f95b9f729c56fe8a4041899f96b72685d36ef16a3440a0f85da8",
+                "sha256:819f8d5197c2684524637f940445c06e003c4a541f9983fd30d6deaa2a5487d8",
+                "sha256:825ecffd9574557590e3225560a8a9d751f6ffe4a49e3c40918c9969b93395fa",
+                "sha256:9009e917d8f5ef780c2626e29b6bc126f4cb2a4d43ca67aa2b40f2a5d6385e78",
+                "sha256:9c77564a51d4d914ed5af096cd9843d90c45b784b511723bd46a8a9d09cf16fc",
+                "sha256:a19089fa74ed19c4fe96502a291cfdb89223a9705b1d73b3005df4256976142e",
+                "sha256:a40ed527bffa2b7ebe07acc5a3f782da072e262ca994b4f2085100b5a444bbb2",
+                "sha256:bb75ba21d5716abc41af16eac1145ab2e471deedde1f22c6f99bd9f995504df0",
+                "sha256:e22a00c0c81ffcecaf07c2bfb3672fa372c50e2bd1024ffee0da191c1b27fc71",
+                "sha256:e55b5a746fb77f10c83e8af081979351722f6ea48facea79d470b3731c7b2891",
+                "sha256:ec2fa3ee81707a5232bf2dfbd6623fdb278e070d596effc7e2d788f2ada71a05",
+                "sha256:fd82eb4694be712fcae03c717ca2e0fc720657ac226b80bbb597e971fc6928c2"
             ],
-            "version": "==1.13.0"
+            "version": "==1.13.1"
         },
         "chardet": {
             "hashes": [
@@ -130,6 +128,20 @@
                 "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
+        },
+        "coreapi": {
+            "hashes": [
+                "sha256:46145fcc1f7017c076a2ef684969b641d18a2991051fddec9458ad3f78ffc1cb",
+                "sha256:bf39d118d6d3e171f10df9ede5666f63ad80bba9a29a8ec17726a66cf52ee6f3"
+            ],
+            "version": "==2.3.3"
+        },
+        "coreschema": {
+            "hashes": [
+                "sha256:5e6ef7bf38c1525d5e55a895934ab4273548629f16aed5c0a6caa74ebf45551f",
+                "sha256:9503506007d482ab0867ba14724b93c18a33b22b6d19fb419ef2d239dd4a1607"
+            ],
+            "version": "==0.0.4"
         },
         "cryptography": {
             "hashes": [
@@ -261,6 +273,14 @@
             ],
             "version": "==0.15.2"
         },
+        "drf-yasg": {
+            "hashes": [
+                "sha256:4cfec631880ae527a91ec7cd3241aea2f82189f59e2f089119aa687761afb227",
+                "sha256:504cce09035cf1bace63b84d9d778b772f86bb37d8a71ed6f723346362e633b2"
+            ],
+            "index": "pypi",
+            "version": "==1.17.0"
+        },
         "idna": {
             "hashes": [
                 "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
@@ -274,6 +294,25 @@
                 "sha256:d5f18a79777f3aa179c145737780282e27b508fc8fd688cb17c7a813e8bd39af"
             ],
             "version": "==0.23"
+        },
+        "inflection": {
+            "hashes": [
+                "sha256:18ea7fb7a7d152853386523def08736aa8c32636b047ade55f7578c4edeb16ca"
+            ],
+            "version": "==0.3.1"
+        },
+        "itypes": {
+            "hashes": [
+                "sha256:c6e77bb9fd68a4bfeb9d958fea421802282451a25bac4913ec94db82a899c073"
+            ],
+            "version": "==1.1.0"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:74320bb91f31270f9551d46522e33af46a80c3d619f4a4bf42b3164d30b5911f",
+                "sha256:9fe95f19286cfefaa917656583d020be14e7859c6b0252588391e47db34527de"
+            ],
+            "version": "==2.10.3"
         },
         "jmespath": {
             "hashes": [
@@ -289,6 +328,39 @@
             ],
             "version": "==4.6.5"
         },
+        "markupsafe": {
+            "hashes": [
+                "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
+                "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
+                "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
+                "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
+                "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
+                "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
+                "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
+                "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
+                "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
+                "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
+                "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
+                "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
+                "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
+                "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
+                "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
+                "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
+                "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
+                "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
+                "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
+                "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
+                "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
+                "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
+                "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
+                "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
+                "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
+                "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
+                "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
+                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"
+            ],
+            "version": "==1.1.1"
+        },
         "more-itertools": {
             "hashes": [
                 "sha256:409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832",
@@ -296,21 +368,28 @@
             ],
             "version": "==7.2.0"
         },
+        "packaging": {
+            "hashes": [
+                "sha256:28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47",
+                "sha256:d9551545c6d761f3def1677baf08ab2a3ca17c56879e70fecba2fc4dde4ed108"
+            ],
+            "version": "==19.2"
+        },
         "psycopg2": {
             "hashes": [
-                "sha256:128d0fa910ada0157bba1cb74a9c5f92bb8a1dca77cf91a31eb274d1f889e001",
-                "sha256:227fd46cf9b7255f07687e5bde454d7d67ae39ca77e170097cdef8ebfc30c323",
-                "sha256:2315e7f104681d498ccf6fd70b0dba5bce65d60ac92171492bfe228e21dcc242",
-                "sha256:4b5417dcd2999db0f5a891d54717cfaee33acc64f4772c4bc574d4ff95ed9d80",
-                "sha256:640113ddc943522aaf71294e3f2d24013b0edd659b7820621492c9ebd3a2fb0b",
-                "sha256:897a6e838319b4bf648a574afb6cabcb17d0488f8c7195100d48d872419f4457",
-                "sha256:8dceca81409898c870e011c71179454962dec152a1a6b86a347f4be74b16d864",
-                "sha256:b1b8e41da09a0c3ef0b3d4bb72da0dde2abebe583c1e8462973233fd5ad0235f",
-                "sha256:cb407fccc12fc29dc331f2b934913405fa49b9b75af4f3a72d0f50f57ad2ca23",
-                "sha256:d3a27550a8185e53b244ad7e79e307594b92fede8617d80200a8cce1fba2c60f",
-                "sha256:f0e6b697a975d9d3ccd04135316c947dd82d841067c7800ccf622a8717e98df1"
+                "sha256:47fc642bf6f427805daf52d6e52619fe0637648fe27017062d898f3bf891419d",
+                "sha256:72772181d9bad1fa349792a1e7384dde56742c14af2b9986013eb94a240f005b",
+                "sha256:8396be6e5ff844282d4d49b81631772f80dabae5658d432202faf101f5283b7c",
+                "sha256:893c11064b347b24ecdd277a094413e1954f8a4e8cdaf7ffbe7ca3db87c103f0",
+                "sha256:965c4c93e33e6984d8031f74e51227bd755376a9df6993774fd5b6fb3288b1f4",
+                "sha256:9ab75e0b2820880ae24b7136c4d230383e07db014456a476d096591172569c38",
+                "sha256:b0845e3bdd4aa18dc2f9b6fb78fbd3d9d371ad167fd6d1b7ad01c0a6cdad4fc6",
+                "sha256:dca2d7203f0dfce8ea4b3efd668f8ea65cd2b35112638e488a4c12594015f67b",
+                "sha256:ed686e5926929887e2c7ae0a700e32c6129abb798b4ad2b846e933de21508151",
+                "sha256:ef6df7e14698e79c59c7ee7cf94cd62e5b869db369ed4b1b8f7b729ea825712a",
+                "sha256:f898e5cc0a662a9e12bde6f931263a1bbd350cfb18e1d5336a12927851825bb6"
             ],
-            "version": "==2.8.3"
+            "version": "==2.8.4"
         },
         "psycopg2-binary": {
             "hashes": [
@@ -396,6 +475,13 @@
             ],
             "version": "==1.7.1"
         },
+        "pyparsing": {
+            "hashes": [
+                "sha256:6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80",
+                "sha256:d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4"
+            ],
+            "version": "==2.4.2"
+        },
         "python-crontab": {
             "hashes": [
                 "sha256:ef1eef66c75fa95a934e203e18721987e7824f9b40cad698edbcfaf2ace11d6c"
@@ -433,6 +519,37 @@
             "index": "pypi",
             "version": "==2.21.0"
         },
+        "ruamel.yaml": {
+            "hashes": [
+                "sha256:0db639b1b2742dae666c6fc009b8d1931ef15c9276ef31c0673cc6dcf766cf40",
+                "sha256:412a6f5cfdc0525dee6a27c08f5415c7fd832a7afcb7a0ed7319628aed23d408"
+            ],
+            "version": "==0.16.5"
+        },
+        "ruamel.yaml.clib": {
+            "hashes": [
+                "sha256:1e77424825caba5553bbade750cec2277ef130647d685c2b38f68bc03453bac6",
+                "sha256:392b7c371312abf27fb549ec2d5e0092f7ef6e6c9f767bfb13e83cb903aca0fd",
+                "sha256:4d55386129291b96483edcb93b381470f7cd69f97585829b048a3d758d31210a",
+                "sha256:550168c02d8de52ee58c3d8a8193d5a8a9491a5e7b2462d27ac5bf63717574c9",
+                "sha256:57933a6986a3036257ad7bf283529e7c19c2810ff24c86f4a0cfeb49d2099919",
+                "sha256:615b0396a7fad02d1f9a0dcf9f01202bf9caefee6265198f252c865f4227fcc6",
+                "sha256:77556a7aa190be9a2bd83b7ee075d3df5f3c5016d395613671487e79b082d784",
+                "sha256:7aee724e1ff424757b5bd8f6c5bbdb033a570b2b4683b17ace4dbe61a99a657b",
+                "sha256:8073c8b92b06b572e4057b583c3d01674ceaf32167801fe545a087d7a1e8bf52",
+                "sha256:9c6d040d0396c28d3eaaa6cb20152cb3b2f15adf35a0304f4f40a3cf9f1d2448",
+                "sha256:a0ff786d2a7dbe55f9544b3f6ebbcc495d7e730df92a08434604f6f470b899c5",
+                "sha256:b1b7fcee6aedcdc7e62c3a73f238b3d080c7ba6650cd808bce8d7761ec484070",
+                "sha256:b66832ea8077d9b3f6e311c4a53d06273db5dc2db6e8a908550f3c14d67e718c",
+                "sha256:d0d3ac228c9bbab08134b4004d748cf9f8743504875b3603b3afbb97e3472947",
+                "sha256:d10e9dd744cf85c219bf747c75194b624cc7a94f0c80ead624b06bfa9f61d3bc",
+                "sha256:ea4362548ee0cbc266949d8a441238d9ad3600ca9910c3fe4e82ee3a50706973",
+                "sha256:ed5b3698a2bb241b7f5cbbe277eaa7fe48b07a58784fba4f75224fd066d253ad",
+                "sha256:f9dcc1ae73f36e8059589b601e8e4776b9976effd76c21ad6a855a74318efd6e"
+            ],
+            "markers": "platform_python_implementation == 'CPython' and python_version < '3.8'",
+            "version": "==0.2.0"
+        },
         "s3transfer": {
             "hashes": [
                 "sha256:6efc926738a3cd576c2a79725fed9afde92378aa5c6a957e3af010cb019fac9d",
@@ -453,6 +570,14 @@
                 "sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873"
             ],
             "version": "==0.3.0"
+        },
+        "uritemplate": {
+            "hashes": [
+                "sha256:01c69f4fe8ed503b2951bef85d996a9d22434d2431584b5b107b2981ff416fbd",
+                "sha256:1b9c467a940ce9fb9f50df819e8ddd14696f89b9a8cc87ac77952ba416e0a8fd",
+                "sha256:c02643cebe23fc8adb5e6becffe201185bf06c40bda5c0b4028a93f1527d011d"
+            ],
+            "version": "==3.0.0"
         },
         "urllib3": {
             "hashes": [

--- a/backend/audits/views.py
+++ b/backend/audits/views.py
@@ -20,7 +20,7 @@ from projects.models import Page, Project, Script
 @swagger_auto_schema(
     methods=["post"],
     responses={201: openapi.Response("Returns the created audits", AuditSerializer)},
-    tags=["Audit"],
+    tags=["Audits"],
 )
 @api_view(["POST"])
 @permission_classes([permissions.IsAuthenticated])
@@ -66,7 +66,7 @@ def request_audit(request, project_uuid):
             "Returns the status of a given audit", AuditStatusHistorySerializer
         )
     },
-    tags=["Audit"],
+    tags=["Audits"],
 )
 @api_view(["GET"])
 @permission_classes([permissions.IsAuthenticated])
@@ -99,7 +99,7 @@ def audit_status(request, audit_uuid):
             "Returns the results of a given audit", AuditResultsSerializer
         )
     },
-    tags=["Audit"],
+    tags=["Audits"],
 )
 @api_view(["GET"])
 @permission_classes([permissions.IsAuthenticated])
@@ -129,7 +129,7 @@ def audit_results(request, audit_uuid):
             AuditResultsSerializer(many=True),
         )
     },
-    tags=["Audit"],
+    tags=["Audits"],
 )
 @api_view(["GET"])
 @permission_classes([permissions.IsAuthenticated])

--- a/backend/audits/views.py
+++ b/backend/audits/views.py
@@ -1,4 +1,10 @@
 import datetime
+from django.http import JsonResponse
+from django.shortcuts import get_object_or_404
+from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework import permissions, status
+from rest_framework.decorators import api_view, permission_classes
 
 from audits.models import Audit, AuditResults, AuditStatusHistory, AvailableStatuses
 from audits.serializers import (
@@ -8,13 +14,14 @@ from audits.serializers import (
 )
 from audits.tasks import request_audit as task_request_audit
 from projects.permissions import check_if_member_of_project
-from django.http import JsonResponse
-from django.shortcuts import get_object_or_404
 from projects.models import Page, Project, Script
-from rest_framework import permissions, status
-from rest_framework.decorators import api_view, permission_classes
 
 
+@swagger_auto_schema(
+    methods=["post"],
+    responses={201: openapi.Response("Returns the created audits", AuditSerializer)},
+    tags=["Audit"],
+)
 @api_view(["POST"])
 @permission_classes([permissions.IsAuthenticated])
 def request_audit(request, project_uuid):
@@ -52,6 +59,15 @@ def request_audit(request, project_uuid):
         )
 
 
+@swagger_auto_schema(
+    methods=["get"],
+    responses={
+        200: openapi.Response(
+            "Returns the status of a given audit", AuditStatusHistorySerializer
+        )
+    },
+    tags=["Audit"],
+)
 @api_view(["GET"])
 @permission_classes([permissions.IsAuthenticated])
 def audit_status(request, audit_uuid):
@@ -76,6 +92,15 @@ def audit_status(request, audit_uuid):
         return JsonResponse(serializer.data, safe=False)
 
 
+@swagger_auto_schema(
+    methods=["get"],
+    responses={
+        200: openapi.Response(
+            "Returns the results of a given audit", AuditResultsSerializer
+        )
+    },
+    tags=["Audit"],
+)
 @api_view(["GET"])
 @permission_classes([permissions.IsAuthenticated])
 def audit_results(request, audit_uuid):
@@ -96,6 +121,16 @@ def audit_results(request, audit_uuid):
         return JsonResponse(serializer.data, safe=False)
 
 
+@swagger_auto_schema(
+    methods=["get"],
+    responses={
+        200: openapi.Response(
+            "Returns the full information of all audit results for a given page",
+            AuditResultsSerializer(many=True),
+        )
+    },
+    tags=["Audit"],
+)
 @api_view(["GET"])
 @permission_classes([permissions.IsAuthenticated])
 def audits_results(request):

--- a/backend/core/serializers.py
+++ b/backend/core/serializers.py
@@ -4,6 +4,7 @@ from rest_framework import serializers
 
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
+        ref_name = "core.user"
         model = User
         fields = ("id", "first_name", "last_name", "email", "username")
 

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -15,7 +15,7 @@ from core.serializers import UserSerializer, UserIdAndNameSerializer
             "Returns the full information of the current user", UserSerializer
         )
     },
-    tags=["User"],
+    tags=["Users"],
 )
 @api_view(["GET"])
 @permission_classes([permissions.IsAuthenticated])
@@ -33,7 +33,7 @@ def user_infos(request):
             UserIdAndNameSerializer(many=True),
         )
     },
-    tags=["User"],
+    tags=["Users"],
 )
 @api_view(["GET"])
 @permission_classes([permissions.IsAuthenticated])

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1,11 +1,22 @@
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
-from core.models import User
-from core.serializers import UserSerializer, UserIdAndNameSerializer
+from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema
 from rest_framework import permissions
 from rest_framework.decorators import api_view, permission_classes
+from core.models import User
+from core.serializers import UserSerializer, UserIdAndNameSerializer
 
 
+@swagger_auto_schema(
+    methods=["get"],
+    responses={
+        200: openapi.Response(
+            "Returns the full information of the current user", UserSerializer
+        )
+    },
+    tags=["User"],
+)
 @api_view(["GET"])
 @permission_classes([permissions.IsAuthenticated])
 def user_infos(request):
@@ -14,6 +25,16 @@ def user_infos(request):
     return JsonResponse(serializer.data)
 
 
+@swagger_auto_schema(
+    methods=["get"],
+    responses={
+        200: openapi.Response(
+            "Returns a list of all the users (id and name)",
+            UserIdAndNameSerializer(many=True),
+        )
+    },
+    tags=["User"],
+)
 @api_view(["GET"])
 @permission_classes([permissions.IsAuthenticated])
 def all_users(request):

--- a/backend/projects/serializers.py
+++ b/backend/projects/serializers.py
@@ -127,6 +127,16 @@ class ProjectMemberRoleSerializer(serializers.ModelSerializer):
 
 
 class ProjectSerializer(DynamicFieldsModelSerializer):
+    has_siblings = serializers.SerializerMethodField("_has_siblings")
+
+    def _has_siblings(self, obj) -> bool:
+        return (
+            Project.objects.filter(
+                members__id=self.context.get("user_id"), is_active=True
+            ).count()
+            > 1
+        )
+
     pages = PageSerializer(many=True)
     scripts = ScriptSerializer(many=True)
     audit_parameters_list = ProjectAuditParametersSerializer(many=True)
@@ -146,4 +156,5 @@ class ProjectSerializer(DynamicFieldsModelSerializer):
             "screenshot_url",
             "latest_audit_at",
             "wpt_api_key",
+            "has_siblings",
         )

--- a/backend/projects/views.py
+++ b/backend/projects/views.py
@@ -1,6 +1,8 @@
 from core.models import User
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404
+from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema
 from projects.models import (
     Page,
     Project,
@@ -22,6 +24,7 @@ from projects.permissions import (
     check_if_admin_of_project,
     is_admin_of_project,
 )
+from rest_framework.response import Response
 from rest_framework import permissions, status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.parsers import JSONParser
@@ -31,16 +34,33 @@ def get_user_projects(user_id):
     return Project.objects.filter(members__id=user_id, is_active=True)
 
 
+@swagger_auto_schema(
+    methods=["get"],
+    responses={
+        200: openapi.Response(
+            "Returns a list of all the user’s projects", ProjectSerializer(many=True)
+        )
+    },
+    tags=["Project"],
+)
+@swagger_auto_schema(
+    methods=["post"],
+    request_body=ProjectSerializer,
+    responses={201: openapi.Response("Returns the created project", ProjectSerializer)},
+    tags=["Project"],
+)
 @api_view(["GET", "POST"])
 @permission_classes([permissions.IsAuthenticated])
 def project_list(request):
     if request.method == "GET":
         projects = get_user_projects(request.user.id)
-        serializer = ProjectSerializer(projects, many=True)
+        serializer = ProjectSerializer(
+            projects, many=True, context={"user_id": request.user.id}
+        )
         return JsonResponse(serializer.data, safe=False)
     elif request.method == "POST":
         data = JSONParser().parse(request)
-        serializer = ProjectSerializer(data=data)
+        serializer = ProjectSerializer(data=data, context={"user_id": request.user.id})
         if serializer.is_valid():
             project = Project.objects.create(**serializer.validated_data)
             project.save()
@@ -51,19 +71,43 @@ def project_list(request):
         return JsonResponse(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
+@swagger_auto_schema(
+    methods=["get"],
+    responses={200: openapi.Response("", ProjectSerializer)},
+    tags=["Project"],
+)
 @api_view(["GET"])
 @permission_classes([permissions.IsAuthenticated])
 def first_project(request):
-    """returns the first project of the user, a boolean that indicates whether
-    the user has other projects.
-    This will speed up the loading of the first project page"""
+    """Returns the first project of the user.
+    This is used to speed up the loading of the first project page"""
     projects = get_user_projects(request.user.id)
-    serializer = ProjectSerializer(projects.first())
-    return JsonResponse(
-        {"project": serializer.data, "has_siblings": projects.count() > 1}
+    serializer = ProjectSerializer(
+        projects.first(), context={"user_id": request.user.id}
     )
+    return JsonResponse(serializer.data)
 
 
+@swagger_auto_schema(
+    methods=["get"],
+    responses={
+        200: openapi.Response("Returns details of a project.", ProjectSerializer)
+    },
+    tags=["Project"],
+)
+@swagger_auto_schema(
+    methods=["put"],
+    request_body=ProjectSerializer,
+    responses={
+        200: openapi.Response(
+            "Update a project. Allows for partial updates.", ProjectSerializer
+        )
+    },
+    tags=["Project"],
+)
+@swagger_auto_schema(
+    methods=["delete"], responses={204: "No content"}, tags=["Project"]
+)
 @api_view(["GET", "PUT", "DELETE"])
 @permission_classes([permissions.IsAuthenticated])
 def project_detail(request, project_uuid):
@@ -71,12 +115,11 @@ def project_detail(request, project_uuid):
     check_if_member_of_project(request.user.id, project.uuid)
 
     if request.method == "GET":
-        projects = get_user_projects(request.user.id)
         if is_admin_of_project(request.user.id, project.uuid):
-            serializer = ProjectSerializer(project)
-            return JsonResponse(
-                {"project": serializer.data, "has_siblings": projects.count() > 1}
+            serializer = ProjectSerializer(
+                project, context={"user_id": request.user.id}
             )
+            return JsonResponse(serializer.data)
         serializer = ProjectSerializer(
             project,
             fields=(
@@ -89,15 +132,16 @@ def project_detail(request, project_uuid):
                 "screenshot_url",
                 "latest_audit_at",
             ),
+            context={"user_id": request.user.id},
         )
-        return JsonResponse(
-            {"project": serializer.data, "has_siblings": projects.count() > 1}
-        )
+        return JsonResponse(serializer.data)
 
     elif request.method == "PUT":
         check_if_admin_of_project(request.user.id, project.uuid)
         data = JSONParser().parse(request)
-        serializer = ProjectSerializer(project, data=data, partial=True)
+        serializer = ProjectSerializer(
+            project, data=data, partial=True, context={"user_id": request.user.id}
+        )
         if serializer.is_valid():
             serializer.save()
             return JsonResponse(serializer.data)
@@ -109,6 +153,21 @@ def project_detail(request, project_uuid):
         return JsonResponse({}, status=status.HTTP_204_NO_CONTENT)
 
 
+@swagger_auto_schema(
+    methods=["get"],
+    responses={
+        200: openapi.Response(
+            "Returns a list of all pages in the project", PageSerializer(many=True)
+        )
+    },
+    tags=["Project"],
+)
+@swagger_auto_schema(
+    methods=["post"],
+    request_body=PageSerializer,
+    responses={201: openapi.Response("Returns the created project", PageSerializer)},
+    tags=["Project"],
+)
 @api_view(["GET", "POST"])
 @permission_classes([permissions.IsAuthenticated])
 def project_page_list(request, project_uuid):
@@ -132,6 +191,24 @@ def project_page_list(request, project_uuid):
         return JsonResponse(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
+@swagger_auto_schema(
+    methods=["get"],
+    responses={200: openapi.Response("Returns details of a page.", PageSerializer)},
+    tags=["Project"],
+)
+@swagger_auto_schema(
+    methods=["put"],
+    request_body=PageSerializer,
+    responses={
+        200: openapi.Response(
+            "Update a page. Allows for partial updates.", PageSerializer
+        )
+    },
+    tags=["Project"],
+)
+@swagger_auto_schema(
+    methods=["delete"], responses={204: "No content"}, tags=["Project"]
+)
 @api_view(["GET", "PUT", "DELETE"])
 @permission_classes([permissions.IsAuthenticated])
 def project_page_detail(request, project_uuid, page_uuid):
@@ -161,6 +238,17 @@ def project_page_detail(request, project_uuid, page_uuid):
         return JsonResponse({}, status=status.HTTP_204_NO_CONTENT)
 
 
+@swagger_auto_schema(
+    methods=["post"],
+    request_body=ProjectAuditParametersSerializer,
+    responses={
+        201: openapi.Response(
+            "Returns the created project audit parameter",
+            ProjectAuditParametersSerializer,
+        )
+    },
+    tags=["Project"],
+)
 @api_view(["POST"])
 @permission_classes([permissions.IsAuthenticated])
 def project_audit_parameter_list(request, project_uuid):
@@ -178,6 +266,30 @@ def project_audit_parameter_list(request, project_uuid):
     return JsonResponse(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
+@swagger_auto_schema(
+    methods=["get"],
+    responses={
+        200: openapi.Response(
+            "Returns details of a project audit parameter.",
+            ProjectAuditParametersSerializer,
+        )
+    },
+    tags=["Project"],
+)
+@swagger_auto_schema(
+    methods=["put"],
+    request_body=ProjectAuditParametersSerializer,
+    responses={
+        200: openapi.Response(
+            "Update a project audit parameter. Allows for partial updates.",
+            ProjectAuditParametersSerializer,
+        )
+    },
+    tags=["Project"],
+)
+@swagger_auto_schema(
+    methods=["delete"], responses={204: "No content"}, tags=["Project"]
+)
 @api_view(["GET", "PUT", "DELETE"])
 @permission_classes([permissions.IsAuthenticated])
 def project_audit_parameters_detail(request, project_uuid, audit_parameters_uuid):
@@ -209,6 +321,20 @@ def project_audit_parameters_detail(request, project_uuid, audit_parameters_uuid
         return JsonResponse({}, status=status.HTTP_204_NO_CONTENT)
 
 
+@swagger_auto_schema(
+    methods=["put"],
+    request_body=ProjectMemberRoleSerializer,
+    responses={
+        200: openapi.Response(
+            "Update a project member. Allows for partial updates.",
+            ProjectMemberRoleSerializer,
+        )
+    },
+    tags=["Project"],
+)
+@swagger_auto_schema(
+    methods=["delete"], responses={204: "No content"}, tags=["Project"]
+)
 @api_view(["PUT", "DELETE"])
 @permission_classes([permissions.IsAuthenticated])
 def project_member_detail(request, project_uuid, user_id):
@@ -240,6 +366,18 @@ def project_member_detail(request, project_uuid, user_id):
         return JsonResponse({}, status=status.HTTP_204_NO_CONTENT)
 
 
+@swagger_auto_schema(
+    methods=["post"],
+    request_body=openapi.Schema(
+        type="object", properties={"user_id": openapi.Schema(type="string")}
+    ),
+    responses={
+        201: openapi.Response(
+            "Returns the updated project with the new member.", ProjectSerializer
+        )
+    },
+    tags=["Project"],
+)
 @api_view(["POST"])
 @permission_classes([permissions.IsAuthenticated])
 def project_members(request, project_uuid):
@@ -269,16 +407,30 @@ def project_members(request, project_uuid):
     )
 
 
+@swagger_auto_schema(
+    methods=["get"],
+    responses={
+        200: openapi.Response("response description", AvailableAuditParameterSerializer)
+    },
+    tags=["Audits"],
+)
 @api_view(["GET"])
 @permission_classes([permissions.IsAuthenticated])
 def available_audit_parameters(request):
+    """user_detail fbv docstring"""
     available_audit_parameters = AvailableAuditParameters.objects.filter(is_active=True)
     serializer = AvailableAuditParameterSerializer(
         available_audit_parameters, many=True
     )
-    return JsonResponse(serializer.data, safe=False)
+    return Response(serializer.data)
 
 
+@swagger_auto_schema(
+    methods=["post"],
+    request_body=ScriptSerializer,
+    responses={200: openapi.Response("response description", ScriptSerializer)},
+    tags=["Project"],
+)
 @api_view(["POST"])
 @permission_classes([permissions.IsAuthenticated])
 def project_scripts(request, project_uuid):
@@ -295,6 +447,19 @@ def project_scripts(request, project_uuid):
     return JsonResponse(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
+@swagger_auto_schema(
+    methods=["put"],
+    request_body=ScriptSerializer,
+    responses={
+        200: openapi.Response(
+            "Update a script. Allows for partial updates.", ScriptSerializer
+        )
+    },
+    tags=["Project"],
+)
+@swagger_auto_schema(
+    methods=["delete"], responses={204: "No content"}, tags=["Project"]
+)
 @api_view(["PUT", "DELETE"])
 @permission_classes([permissions.IsAuthenticated])
 def project_script_detail(request, project_uuid, script_uuid):

--- a/backend/projects/views.py
+++ b/backend/projects/views.py
@@ -409,9 +409,12 @@ def project_members(request, project_uuid):
 @swagger_auto_schema(
     methods=["get"],
     responses={
-        200: openapi.Response("response description", AvailableAuditParameterSerializer)
+        200: openapi.Response(
+            "Returns all WebPageTest available audit parameters",
+            AvailableAuditParameterSerializer,
+        )
     },
-    tags=["Audits"],
+    tags=["Project"],
 )
 @api_view(["GET"])
 @permission_classes([permissions.IsAuthenticated])
@@ -427,7 +430,7 @@ def available_audit_parameters(request):
 @swagger_auto_schema(
     methods=["post"],
     request_body=ScriptSerializer,
-    responses={200: openapi.Response("response description", ScriptSerializer)},
+    responses={201: openapi.Response("Returns the created script", ScriptSerializer)},
     tags=["Project"],
 )
 @api_view(["POST"])

--- a/backend/projects/views.py
+++ b/backend/projects/views.py
@@ -40,13 +40,13 @@ def get_user_projects(user_id):
             "Returns a list of all the user’s projects", ProjectSerializer(many=True)
         )
     },
-    tags=["Project"],
+    tags=["Projects"],
 )
 @swagger_auto_schema(
     methods=["post"],
     request_body=ProjectSerializer,
     responses={201: openapi.Response("Returns the created project", ProjectSerializer)},
-    tags=["Project"],
+    tags=["Projects"],
 )
 @api_view(["GET", "POST"])
 @permission_classes([permissions.IsAuthenticated])
@@ -73,7 +73,7 @@ def project_list(request):
 @swagger_auto_schema(
     methods=["get"],
     responses={200: openapi.Response("", ProjectSerializer)},
-    tags=["Project"],
+    tags=["Projects"],
 )
 @api_view(["GET"])
 @permission_classes([permissions.IsAuthenticated])
@@ -92,20 +92,20 @@ def first_project(request):
     responses={
         200: openapi.Response("Returns details of a project.", ProjectSerializer)
     },
-    tags=["Project"],
+    tags=["Projects"],
 )
 @swagger_auto_schema(
     methods=["put"],
     request_body=ProjectSerializer,
     responses={
         200: openapi.Response(
-            "Update a project. Allows for partial updates.", ProjectSerializer
+            "Updates a project. Allows for partial updates.", ProjectSerializer
         )
     },
-    tags=["Project"],
+    tags=["Projects"],
 )
 @swagger_auto_schema(
-    methods=["delete"], responses={204: "No content"}, tags=["Project"]
+    methods=["delete"], responses={204: "No content"}, tags=["Projects"]
 )
 @api_view(["GET", "PUT", "DELETE"])
 @permission_classes([permissions.IsAuthenticated])
@@ -159,13 +159,13 @@ def project_detail(request, project_uuid):
             "Returns a list of all pages in the project", PageSerializer(many=True)
         )
     },
-    tags=["Project"],
+    tags=["Pages"],
 )
 @swagger_auto_schema(
     methods=["post"],
     request_body=PageSerializer,
-    responses={201: openapi.Response("Returns the created project", PageSerializer)},
-    tags=["Project"],
+    responses={201: openapi.Response("Returns the created page", PageSerializer)},
+    tags=["Pages"],
 )
 @api_view(["GET", "POST"])
 @permission_classes([permissions.IsAuthenticated])
@@ -193,21 +193,19 @@ def project_page_list(request, project_uuid):
 @swagger_auto_schema(
     methods=["get"],
     responses={200: openapi.Response("Returns details of a page.", PageSerializer)},
-    tags=["Project"],
+    tags=["Pages"],
 )
 @swagger_auto_schema(
     methods=["put"],
     request_body=PageSerializer,
     responses={
         200: openapi.Response(
-            "Update a page. Allows for partial updates.", PageSerializer
+            "Updates a page. Allows for partial updates.", PageSerializer
         )
     },
-    tags=["Project"],
+    tags=["Pages"],
 )
-@swagger_auto_schema(
-    methods=["delete"], responses={204: "No content"}, tags=["Project"]
-)
+@swagger_auto_schema(methods=["delete"], responses={204: "No content"}, tags=["Pages"])
 @api_view(["GET", "PUT", "DELETE"])
 @permission_classes([permissions.IsAuthenticated])
 def project_page_detail(request, project_uuid, page_uuid):
@@ -246,7 +244,7 @@ def project_page_detail(request, project_uuid, page_uuid):
             ProjectAuditParametersSerializer,
         )
     },
-    tags=["Project"],
+    tags=["Project Audit Parameters"],
 )
 @api_view(["POST"])
 @permission_classes([permissions.IsAuthenticated])
@@ -269,25 +267,25 @@ def project_audit_parameter_list(request, project_uuid):
     methods=["get"],
     responses={
         200: openapi.Response(
-            "Returns details of a project audit parameter.",
+            "Returns the details of a project audit parameter.",
             ProjectAuditParametersSerializer,
         )
     },
-    tags=["Project"],
+    tags=["Project Audit Parameters"],
 )
 @swagger_auto_schema(
     methods=["put"],
     request_body=ProjectAuditParametersSerializer,
     responses={
         200: openapi.Response(
-            "Update a project audit parameter. Allows for partial updates.",
+            "Updates a project audit parameter. Allows for partial updates.",
             ProjectAuditParametersSerializer,
         )
     },
-    tags=["Project"],
+    tags=["Project Audit Parameters"],
 )
 @swagger_auto_schema(
-    methods=["delete"], responses={204: "No content"}, tags=["Project"]
+    methods=["delete"], responses={204: "No content"}, tags=["Project Audit Parameters"]
 )
 @api_view(["GET", "PUT", "DELETE"])
 @permission_classes([permissions.IsAuthenticated])
@@ -325,14 +323,14 @@ def project_audit_parameters_detail(request, project_uuid, audit_parameters_uuid
     request_body=ProjectMemberRoleSerializer,
     responses={
         200: openapi.Response(
-            "Update a project member. Allows for partial updates.",
+            "Updates a project member. Allows for partial updates.",
             ProjectMemberRoleSerializer,
         )
     },
-    tags=["Project"],
+    tags=["Project Members"],
 )
 @swagger_auto_schema(
-    methods=["delete"], responses={204: "No content"}, tags=["Project"]
+    methods=["delete"], responses={204: "No content"}, tags=["Project Members"]
 )
 @api_view(["PUT", "DELETE"])
 @permission_classes([permissions.IsAuthenticated])
@@ -375,7 +373,7 @@ def project_member_detail(request, project_uuid, user_id):
             "Returns the updated project with the new member.", ProjectSerializer
         )
     },
-    tags=["Project"],
+    tags=["Project Members"],
 )
 @api_view(["POST"])
 @permission_classes([permissions.IsAuthenticated])
@@ -414,12 +412,11 @@ def project_members(request, project_uuid):
             AvailableAuditParameterSerializer,
         )
     },
-    tags=["Project"],
+    tags=["Project Audit Parameters"],
 )
 @api_view(["GET"])
 @permission_classes([permissions.IsAuthenticated])
 def available_audit_parameters(request):
-    """user_detail fbv docstring"""
     available_audit_parameters = AvailableAuditParameters.objects.filter(is_active=True)
     serializer = AvailableAuditParameterSerializer(
         available_audit_parameters, many=True
@@ -431,7 +428,7 @@ def available_audit_parameters(request):
     methods=["post"],
     request_body=ScriptSerializer,
     responses={201: openapi.Response("Returns the created script", ScriptSerializer)},
-    tags=["Project"],
+    tags=["Scripts"],
 )
 @api_view(["POST"])
 @permission_classes([permissions.IsAuthenticated])
@@ -454,13 +451,13 @@ def project_scripts(request, project_uuid):
     request_body=ScriptSerializer,
     responses={
         200: openapi.Response(
-            "Update a script. Allows for partial updates.", ScriptSerializer
+            "Updates a script. Allows for partial updates.", ScriptSerializer
         )
     },
-    tags=["Project"],
+    tags=["Scripts"],
 )
 @swagger_auto_schema(
-    methods=["delete"], responses={204: "No content"}, tags=["Project"]
+    methods=["delete"], responses={204: "No content"}, tags=["Scripts"]
 )
 @api_view(["PUT", "DELETE"])
 @permission_classes([permissions.IsAuthenticated])

--- a/backend/projects/views.py
+++ b/backend/projects/views.py
@@ -3,6 +3,9 @@ from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
+from rest_framework import permissions, status
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.parsers import JSONParser
 from projects.models import (
     Page,
     Project,
@@ -24,10 +27,6 @@ from projects.permissions import (
     check_if_admin_of_project,
     is_admin_of_project,
 )
-from rest_framework.response import Response
-from rest_framework import permissions, status
-from rest_framework.decorators import api_view, permission_classes
-from rest_framework.parsers import JSONParser
 
 
 def get_user_projects(user_id):
@@ -422,7 +421,7 @@ def available_audit_parameters(request):
     serializer = AvailableAuditParameterSerializer(
         available_audit_parameters, many=True
     )
-    return Response(serializer.data)
+    return JsonResponse(serializer.data)
 
 
 @swagger_auto_schema(

--- a/backend/root/settings/base.py
+++ b/backend/root/settings/base.py
@@ -29,6 +29,7 @@ INSTALLED_APPS = [
     "memoize",
     "rest_framework",
     "djoser",
+    "drf_yasg",
     # Our apps
     "front",
     "core",
@@ -127,3 +128,9 @@ if "REDIS_URL" in os.environ:
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.1/howto/static-files/
 STATIC_URL = "/static/"
+
+SWAGGER_SETTINGS = {
+    "SECURITY_DEFINITIONS": {
+        "Bearer": {"type": "apiKey", "name": "Authorization", "in": "header"}
+    }
+}

--- a/backend/root/urls.py
+++ b/backend/root/urls.py
@@ -15,12 +15,46 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import include, path
+from django.conf.urls import url
+from rest_framework import permissions
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
+
 from root import views
+
 
 admin.site.site_title = "falco Site Admin"
 admin.site.site_header = "falco Administration"
 
+schema_view = get_schema_view(
+    openapi.Info(
+        title="Falco API",
+        default_version="",
+        description="""This is the API documentation for this instance of [Falco](https://getfal.co).
+
+If you have any question or would want to raise an issue, head to the [GitHub repository](https://github.com/theodo/falco).
+
+
+To obtain a Falco API Key, you can login to Falco and inspect any XHR call inside the Dev Tools.""",
+        terms_of_service="https://github.com/theodo/falco/blob/master/CODE_OF_CONDUCT.md",
+        contact=openapi.Contact(email="falco@theodo.fr"),
+        license=openapi.License(name="MIT License"),
+    ),
+    public=True,
+    permission_classes=(permissions.AllowAny,),
+)
+
 urlpatterns = [
+    url(
+        r"^swagger(?P<format>\.json|\.yaml)$",
+        schema_view.without_ui(cache_timeout=0),
+        name="schema-json",
+    ),
+    url(
+        r"^swagger/$",
+        schema_view.with_ui("swagger", cache_timeout=0),
+        name="schema-swagger-ui",
+    ),
     path("admin/", admin.site.urls),
     path("auth/", include("front.auth.auth_urls")),
     path("auth/", include("djoser.urls")),

--- a/frontend/src/redux/entities/projects/sagas.ts
+++ b/frontend/src/redux/entities/projects/sagas.ts
@@ -50,7 +50,7 @@ import {
   setProjectToastrDisplay,
 } from './actions';
 import { modelizeProject, modelizeProjects } from './modelizer';
-import { ApiProjectResponseType, ApiProjectType } from './types';
+import { ApiProjectType } from './types';
 
 function* fetchProjectsFailedHandler(error: Error, actionPayload: Record<string, any>) {
   yield put(fetchProjectError({ projectId: actionPayload.currentProjectId, errorMessage: error.message }));
@@ -110,15 +110,15 @@ function* fetchProjects(action: ActionType<typeof fetchProjectsRequest>) {
   const firstProjectEndpoint = action.payload.currentProjectId
     ? `/api/projects/${action.payload.currentProjectId}/`
     : '/api/projects/first';
-  const { body: firstProject }: { body: ApiProjectResponseType } = yield call(
+  const { body: firstProject }: { body: ApiProjectType } = yield call(
     makeGetRequest,
     firstProjectEndpoint,
     true,
     null,
   );
   // if the returned project is empty, put an empty state for projects
-  if (firstProject.project.uuid) {
-    yield put(saveFetchedProjects({ projects: [firstProject.project] }));
+  if (firstProject.uuid) {
+    yield put(saveFetchedProjects({ projects: [firstProject] }));
   } else {
     yield put(fetchProjectError({ projectId: null, errorMessage: "No project returned" }));
     return;
@@ -140,13 +140,13 @@ function* fetchProjects(action: ActionType<typeof fetchProjectsRequest>) {
 
 function* fetchProject(action: ActionType<typeof fetchProjectRequest>) {
   const endpoint = `/api/projects/${action.payload.projectId}/`;
-  const { body: projectResponse }: { body: ApiProjectResponseType } = yield call(
+  const { body: project }: { body: ApiProjectType } = yield call(
     makeGetRequest,
     endpoint,
     true,
     null,
   );
-  yield put(saveFetchedProjects({ projects: [projectResponse.project] }));
+  yield put(saveFetchedProjects({ projects: [project] }));
 };
 
 function* addMemberToProject(action: ActionType<typeof addMemberToProjectRequest>) {

--- a/frontend/src/redux/entities/projects/types.ts
+++ b/frontend/src/redux/entities/projects/types.ts
@@ -25,6 +25,7 @@ export interface ApiProjectType {
   latest_audit_at: string;
   project_members: ApiProjectMember[];
   wpt_api_key: string;
+  has_siblings: boolean;
 };
 
 export interface ProjectMember {
@@ -40,12 +41,6 @@ export interface ApiProjectMember {
   email: string;
   is_admin: boolean;
 }
-
-
-export interface ApiProjectResponseType {
-  project: ApiProjectType;
-  has_siblings: boolean;
-};
 
 export type ProjectToastrDisplayType =
 | ''


### PR DESCRIPTION
Closes #38

![image](https://user-images.githubusercontent.com/2587348/67247828-ce805500-f462-11e9-8309-c7b151c34003.png)

Docs will be available behind `/swagger` (for the Swagger UI) and `/swagger.json` (for the Open API JSON specs).

I went for https://github.com/axnsan12/drf-yasg which was quite easy to add to all routes once I’ve figured it out.

I had to change an endpoint to make it all work though:

```
{
  project: <Project>
  has_siblings: boolean
}
```

became

```
{
  project: <Project with the additional has_siblings property>
}
```

which is cleaner tbh.