### PR TITLE
fix select display dut to missing value attribute

### DIFF
--- a/frontend/src/pages/EnvironmentSettings/Components/AuditParameterTable/AddAuditParameterRow/AddAuditParameterRow.tsx
+++ b/frontend/src/pages/EnvironmentSettings/Components/AuditParameterTable/AddAuditParameterRow/AddAuditParameterRow.tsx
@@ -90,6 +90,15 @@ export const AddAuditParameterRow: React.FunctionComponent<Props> = ({
 
   const selectMargin = `0 ${getSpacing(2)} 0 0`
 
+  const foundAuditParameter = availableAuditParameters.find(auditParametersOption => {
+    return auditParametersOption.uuid === auditParameterConfigurationId;
+  });
+  const auditParameterValue = foundAuditParameter && {
+    ...availableAuditParameters.find(auditParametersOption => {
+      return auditParametersOption.uuid === auditParameterConfigurationId;
+    })
+    , value: auditParameterConfigurationId
+  };
   return (
     <React.Fragment>
       <AddAuditParameterButtonContainer isAdding={isAddingMode} onClick={activateAddingMode}>
@@ -110,9 +119,7 @@ export const AddAuditParameterRow: React.FunctionComponent<Props> = ({
         placeholder={intl.formatMessage({ id: 'ProjectSettings.audit_parameter_name_placeholder' })}
       />
       <Select
-        value={availableAuditParameters.find(auditParametersOption => {
-          return auditParametersOption.uuid === auditParameterConfigurationId;
-        })}
+        value={auditParameterValue}
         onChange={handleConfigurationChange}
         options={availableAuditParameters}
         display={isAddingMode ? 'visible' : 'none'}

--- a/frontend/src/pages/EnvironmentSettings/Components/AuditParameterTable/AuditParameterRow/AuditParameterRow.tsx
+++ b/frontend/src/pages/EnvironmentSettings/Components/AuditParameterTable/AuditParameterRow/AuditParameterRow.tsx
@@ -85,6 +85,16 @@ export const AuditParameterRow: React.FunctionComponent<Props> = ({
 
   const selectMargin = `0 ${getSpacing(2)} 0 0`
 
+
+  const foundAuditParameter = availableAuditParameters.find(auditParametersOption => {
+    return auditParametersOption.uuid === auditParameterConfigurationId;
+  });
+  const auditParameterValue = foundAuditParameter && {
+    ...availableAuditParameters.find(auditParametersOption => {
+      return auditParametersOption.uuid === auditParameterConfigurationId;
+    })
+    , value: auditParameterConfigurationId
+  };
   return (
     <React.Fragment>
       <EditNameInput
@@ -94,9 +104,7 @@ export const AuditParameterRow: React.FunctionComponent<Props> = ({
         onBlur={handleBlur}
       />
       <Select
-        value={availableAuditParameters.find(auditParametersOption => {
-          return auditParametersOption.uuid === auditParameterConfigurationId;
-        })}
+        value={auditParameterValue}
         onChange={handleConfigurationChange}
         options={availableAuditParameters}
         margin={selectMargin}


### PR DESCRIPTION
For audit value, the object value is the `uuid`. But selectors need a `value`