### PR TITLE
Fix ssl check on unsecure database

### DIFF
--- a/backend/root/settings/prod.py
+++ b/backend/root/settings/prod.py
@@ -77,3 +77,6 @@ STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 # Configure app for Heroku deployment
 django_heroku.settings(locals())
+
+if "DISABLE_DATABASE_SSL_CHECK" in os.environ:
+    del DATABASES["default"]["OPTIONS"]["sslmode"]

--- a/docs/docs/getting-started/installation.mdx
+++ b/docs/docs/getting-started/installation.mdx
@@ -91,3 +91,17 @@ To install Falco with `docker-compose`:
 This will start the stack: Redis + PostgreSQL + Celery + the main application. The main application should be available on http://localhost:80.
 
 For a production use, we recommend using a PostreSQL with valid SSL certificates and expose the application with a frontal server managing the HTTPS certificates.
+Without a valid SSL certificate, the application will not work.
+
+The first time the application starts, you will need to manually run the migrations and add some data:
+
+```sh
+docker-composer exec backend sh
+
+# You are now inside the Docker container
+./manage.py migrate --noinput
+./manage.py createcachetable
+# Please change login, mail and password below
+./manage.py shell -c "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('admin', 'yourmail@example.com', 'admin')"
+./manage.py populate-periodic-tasks
+```


### PR DESCRIPTION
Fixes #57 

However, without a valid https certificate, the application will not work:
1. It tries to redirect to HTTPS with a 301 due to `SECURE_SSL_REDIRECT = True` in prod.py
2. CSRF Cookies are set as secure due to `CSRF_COOKIE_SECURE = True` in prod.py. Users cannot send forms.
3. Session Cookies are set as secure due to `SESSION_COOKIE_SECURE = True` in prod.py. Users cannot login.
