### PR TITLE
Improve build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM node:8.12-alpine AS node
 WORKDIR /code
 
 COPY ./frontend/package.json ./frontend/yarn.lock /code/
-RUN yarn install --pure-lockfile
+RUN yarn install --pure-lockfile --ignore-scripts
 
 COPY ./frontend/ /code/
 RUN yarn build

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
+export DOCKER_BUILDKIT=1
+
 # Build the compile stage:
 docker build --target node \
        --cache-from=falco/falco-front:compile-stage \


### PR DESCRIPTION
Work on #26 

Got the yarn install step down to 81s by disabling script (we do not need to extract/install cypress).
